### PR TITLE
Make hack-solidity-version command work on mac

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -2,12 +2,12 @@
   "scripts": {
     "examples": "docusaurus-examples",
     "sync-assets": "rsync -rtu \"$(dirname $(node -p 'require.resolve(\"@aragon/ui\")'))/\" static/aragon-ui",
-    "hack_solidity_version": "find ./node_modules/@aragon/os/contracts -name \"*.sol\" -exec sed -i 's/pragma solidity 0.4.18/pragma solidity ^0.4.18/g' {} \\;",
+    "hack_solidity_version": "find ./node_modules/@aragon/os/contracts -name \"*.sol\" -exec sed -i '' -e 's/pragma solidity 0.4.18/pragma solidity ^0.4.18/g' {} \\;",
     "hack_clean_os_lib_api": "rm -f ../docs/api_lib_*",
     "generate:os": "npm run hack_solidity_version && solidity-docgen --exclude lib node_modules/@aragon/os node_modules/@aragon/os/contracts ../ && npm run hack_clean_os_lib_api",
-    "start": "npm run sync-assets; docusaurus-start",
+    "start": "npm run generate:os && npm run sync-assets && docusaurus-start",
     "build": "npm run generate:os && docusaurus-build",
-    "publish-gh-pages": "USE_SSH=true docusaurus-publish",
+    "publish-gh-pages": "npm run generate:os && USE_SSH=true docusaurus-publish",
     "write-translations": "docusaurus-write-translations",
     "version": "docusaurus-version",
     "rename-version": "docusaurus-rename-version"

--- a/website/package.json
+++ b/website/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "examples": "docusaurus-examples",
     "sync-assets": "rsync -rtu \"$(dirname $(node -p 'require.resolve(\"@aragon/ui\")'))/\" static/aragon-ui",
-    "hack_solidity_version": "find ./node_modules/@aragon/os/contracts -name \"*.sol\" -exec sed -i '' -e 's/pragma solidity 0.4.18/pragma solidity ^0.4.18/g' {} \\;",
+    "hack_solidity_version": "find ./node_modules/@aragon/os/contracts -name \"*.sol\" -exec sed -i'' -e 's/pragma solidity 0.4.18/pragma solidity ^0.4.18/g' {} \\;",
     "hack_clean_os_lib_api": "rm -f ../docs/api_lib_*",
     "generate:os": "npm run hack_solidity_version && solidity-docgen --exclude lib node_modules/@aragon/os node_modules/@aragon/os/contracts ../ && npm run hack_clean_os_lib_api",
     "start": "npm run generate:os && npm run sync-assets && docusaurus-start",


### PR DESCRIPTION
The current command fails on mac

```
> @ hack_solidity_version /Users/jorge/provident/hack-docs/website
> find ./node_modules/@aragon/os/contracts -name "*.sol" -exec sed -i 's/pragma solidity 0.4.18/pragma solidity ^0.4.18/g' {} \;

sed: 1: "./node_modules/@aragon/ ...": invalid command code .
sed: 1: "./node_modules/@aragon/ ...": invalid command code .
sed: 1: "./node_modules/@aragon/ ...": invalid command code .
sed: 1: "./node_modules/@aragon/ ...": invalid command code .
sed: 1: "./node_modules/@aragon/ ...": invalid command code .
sed: 1: "./node_modules/@aragon/ ...": invalid command code .
sed: 1: "./node_modules/@aragon/ ...": invalid command code .
sed: 1: "./node_modules/@aragon/ ...": invalid command code .
sed: 1: "./node_modules/@aragon/ ...": invalid command code .
sed: 1: "./node_modules/@aragon/ ...": invalid command code .
sed: 1: "./node_modules/@aragon/ ...": invalid command code .
sed: 1: "./node_modules/@aragon/ ...": invalid command code .
```

Can you please check this still works on linux?