### PR TITLE
Add instructions to skip initialization on `aragon dao install`

### DIFF
--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -181,6 +181,8 @@ In aragonOS an app is considered to be installed in a DAO if it uses the DAO Ker
 
 The `dao install` command will create an instance of the app and assign permissions to the main account to perform all the protected actions in the app.
 
+By default it will initialize the app using `initialize` function, which can be changed with `--app-init` option, and with arguments provided in `--app-init-args`. If you want to skip app initialization (which is not generally recommended), you can do it by setting `--app-init` to `none`.
+
 As explained in the [upgrade command](#dao-upgrade), all app instances of the same app in DAO must run the same version, so installing an app with a version will effectively upgrade all app instances to this version.
 
 ---


### PR DESCRIPTION
If install command doesn't find initialization method, it won't
initialize the newly installed app, but this is not obvious from the
help instructions.
Although it's "dangerous", sometimes it's useful to install an app
without initializing. For instance, Token Manager: to initialize it
the token must be provided, and this token must have this new Token
Manager app as controller. Therefore token controller must be changed
in between creation and initialization of Token Manager app.