### PR TITLE
chore: upgrade docusaurus

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -15,7 +15,7 @@
     "rename-version": "docusaurus-rename-version"
   },
   "devDependencies": {
-    "@aragon/docusaurus": "^1.0.15",
+    "@aragon/docusaurus": "^1.3.3",
     "node-fetch": "^2.3.0",
     "opn": "^5.3.0",
     "solidity-docgen": "^0.1.0"


### PR DESCRIPTION
Avoids the need to `npm link @aragon/docusaurus` :)