### PR TITLE
Update tutorial to create-aragon-app #74

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -11,7 +11,7 @@ Follow these instructions to immediately run the full tutorial:
 
 ```
 npm i -g @aragon/cli
-aragon init foo.aragonpm.eth react
+npx create-aragon-app foo.aragonpm.eth react
 cd foo
 aragon run
 ```
@@ -31,7 +31,7 @@ npm i -g @aragon/cli
 Next, we bootstrap our project:
 
 ```
-aragon init foo.aragonpm.eth react
+npx create-aragon-app foo.aragonpm.eth react
 ```
 
 This will create a new directory named `foo`, with files cloned from the official Aragon [react boilerplate](https://github.com/aragon/aragon-react-boilerplate). This particular boilerplate includes everything you need to get started — Truffle, aragonOS and aragonAPI.


### PR DESCRIPTION
instead of deprecated ```aragon init``` #74

Installing aragon with ```aragon init``` command emits the following notice:
```
 ✔ Created new application foo.aragonpm.eth in foo.
 ℹ Use of `aragon init` is deprecated and has been replaced with `npx create-aragon-app`.
```
Running the app installed this way with ```aragon run``` command fails with
```
  ✔ Start a local Ethereum network        ✔ Start a local Ethereum network
 ✔ Check IPFS
 ❯ Publish app to APM
   ⠹ Applying version bump (major)
     Deploy contract
     Determine contract address for version
     Building frontend
     Prepare files for publishing
     Generate application artifact
     Publish foo.aragonpm.eth
     Fetch published repo
   Create DAO
   Open DAO

 error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)

ecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```
on MacOS X, npm@6.1.0, @aragon/cli 5.3.2

Also see discussion in aragon/aragon-cli#317 on this