### PR TITLE
add reference to optional token intent parameter

### DIFF
--- a/docs/js-ref-app.md
+++ b/docs/js-ref-app.md
@@ -72,15 +72,15 @@ You can also pass an optional object after all the required function arguments t
 app.increment(1, { gas: 200000, gasPrice: 80000000 })
 ```
 
-You can include a `token` parameter in this optional object if you need to approve before a transaction. A slightly modified [example](https://github.com/aragon/aragon-apps/blob/master/apps/finance/app/src/App.js#L79) from the Finance app:
+You can include a `token` parameter in this optional object if you need to do a token approval before a transaction. A slightly modified [example](https://github.com/aragon/aragon-apps/blob/master/apps/finance/app/src/App.js#L79) from the Finance app:
 
 ```js
-  intentParams = {
-    token: { address: tokenAddress, value: amount }
-    gas: 500000
-  }
+intentParams = {
+  token: { address: tokenAddress, value: amount }
+  gas: 500000
+}
 
-  app.deposit(tokenAddress, amount, reference, intentParams)
+app.deposit(tokenAddress, amount, reference, intentParams)
 ```
 
 Some caveats to customizing transaction parameters:

--- a/docs/js-ref-app.md
+++ b/docs/js-ref-app.md
@@ -72,6 +72,17 @@ You can also pass an optional object after all the required function arguments t
 app.increment(1, { gas: 200000, gasPrice: 80000000 })
 ```
 
+You can include a `token` parameter in this optional object if you need to approve before a transaction. A slightly modified [example](https://github.com/aragon/aragon-apps/blob/master/apps/finance/app/src/App.js#L79) from the Finance app:
+
+```js
+  intentParams = {
+    token: { address: tokenAddress, value: amount }
+    gas: 500000
+  }
+
+  app.deposit(tokenAddress, amount, reference, intentParams)
+```
+
 Some caveats to customizing transaction parameters:
 
 -   `from`, `to`, `data`: will be ignored as aragon.js will calculate those.


### PR DESCRIPTION
This addition to the documentation describes and gives an example for using the optional `token` intent parameter.