### PR TITLE
Add style improvements for the sidebar

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -115,6 +115,8 @@ const siteConfig = {
   /* On page navigation for the current documentation page */
   onPageNav: 'separate',
 
+  docsSideNavCollapsible: true,
+
   /* Open Graph and Twitter card images */
   ogImage: 'img/docusaurus.png',
   twitterImage: 'img/docusaurus.png',


### PR DESCRIPTION
With the new documentation pages is getting harder to include all the sidebar items. Adding collapsable categories fix this problem.

Other great improvement would be to fix the sidebar and prevent it to scroll at the same time as the main page.

TODO:

- [x] Update `@aragon/docusaurus`