### PR TITLE
API: aragonAPI's docs moved to docs/API.md

### DIFF
--- a/docs/api-intro.md
+++ b/docs/api-intro.md
@@ -27,7 +27,7 @@ Some of the things you can do with the JavaScript implementation are:
 #### Docs
 
 - [Quick Start for apps](js-ref-quick-start.md)
-- [App API](js-ref-app.md)
+- [App API](js-ref-api.md)
   - [React API](js-ref-react.md)
 - [Aragon client implementations (wrapper)](js-ref-wrapper.md)
 - [Providers](js-ref-providers.md)

--- a/website/scripts/sync-aragonjs-docs.js
+++ b/website/scripts/sync-aragonjs-docs.js
@@ -13,12 +13,12 @@ const pages = [
     contentLocation: 'docs/QUICK_START.md',
   },
   {
-    destination: '/docs/js-ref-app.md',
-    id: 'api-js-ref-app',
+    destination: '/docs/js-ref-api.md',
+    id: 'api-js-ref-api',
     title: 'aragonAPI for Javascript',
     sidebarLabel: 'App API',
     hideTitle: true,
-    contentLocation: 'docs/APP.md',
+    contentLocation: 'docs/API.md',
   },
   {
     destination: '/docs/js-ref-providers.md',
@@ -63,7 +63,7 @@ const pages = [
 ]
 
 const locationReferenceMap = {
-  '/docs/APP.md': '/docs/api-js-ref-app.html',
+  '/docs/API.md': '/docs/api-js-ref-api.html',
   '/docs/WRAPPER.md': '/docs/api-js-ref-wrapper.html',
   '/docs/PROVIDERS.md': '/docs/api-js-ref-providers.html',
   '/docs/ARCHITECTURE.md': '/docs/api-js-ref-architecture.html',

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -48,7 +48,7 @@
         "label": "JavaScript",
         "ids": [
           "api-js-quick-start",
-          "api-js-ref-app",
+          "api-js-ref-api",
           "api-js-ref-react",
           "api-js-ref-wrapper",
           "api-js-ref-providers",


### PR DESCRIPTION
The API docs in aragon.js have been moved from `docs/APP.md` to `docs/API.md` in https://github.com/aragon/aragon.js/pull/341.