### PR TITLE
Relax solidity version requirement in tutorial contract example

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -35,7 +35,7 @@ Today, we will build a simple counter app — you can increment it, you can decr
 
 ```solidity
 // contracts/CounterApp.sol
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 contract CounterApp {
     // Events


### PR DESCRIPTION
[Currently](https://hack.aragon.org/docs/tutorial#writing-a-simple-contract) the version of compiler is fixed to 0.4.24 and following the tutorial results in error:

```
contracts/CounterApp.sol:1:1: SyntaxError: Source file requires different compiler version (current compiler is 0.4.26+commit.4563c3fc.Emscripten.clang - note that nightly builds are considered to be strictly less than the released version
```