### PR TITLE
Buidler publish guide

### DIFF
--- a/docs/guides-faq.md
+++ b/docs/guides-faq.md
@@ -110,7 +110,9 @@ The best way around this is to:
 
 When publishing a package via `aragon apm publish`, you will be returned an IPFS content (root) hash. For the Aragon client to load these files through its default IPFS configuration, this hash needs to be accessible at `https://ipfs.eth.aragon.network/ipfs/<hash>`.
 
-If you are running into issues with your hash being propagated to this URL, try running `ipfs propagate <hash>` or the following steps.
+The best way to propagate and keep your app's content accessible is to pin it via a cloud IPFS-pinning service like [Pinata](https://pinata.cloud/) or [Temporal](https://temporal.cloud/). These services generally offer a generous free-tier that will allow you to host your app if it is not too large.
+
+Otherwise, as a quick fix, if you are running into issues with your hash being propagated to this URL, try running `ipfs propagate <hash>` or the following steps.
 
 1. If you have `aragon ipfs` running, quit that daemon.
 2. Run the command `ipfs daemon --enable-namesys-pubsub`.

--- a/docs/guides-faq.md
+++ b/docs/guides-faq.md
@@ -12,7 +12,7 @@ sidebar_label: Troubleshooting
 
 If you're seeing several installation errors (e.g. `node-gyp rebuild`), the problem is probably due to an outdated Node.js version.
 
-aragonCLI currently supports the latest releases of the following Node.js versions: 10, 11 and 12.  
+aragonCLI currently supports the latest releases of the following Node.js versions: 10, 11 and 12.
 
 If you're seeing errors similar to:
 
@@ -33,7 +33,7 @@ An arguably better way to fix the problem is to follow the steps outlined in thi
 ### Windows considerations
 
 
-Windows is not officially supported by aragonCLI at the moment. 
+Windows is not officially supported by aragonCLI at the moment.
 
 You might need to run the shell with administrator rights when installing the aragonCLI, because our `go-ipfs` dependency will need to create a symlink to work correctly.
 

--- a/docs/guides-publish.md
+++ b/docs/guides-publish.md
@@ -11,7 +11,7 @@ This guide will show you how to publish an app to [aragonPM](/docs/package-manag
 > **Note**<br>
 > Publishing your app requires an on-chain action so you must connect an Ethereum account with enough funds on the selected environment to send a publish transaction.
 >
-> Secondly, your app's frontend content is uploaded to IPFS and it becomes **your responsibility** to ensure that it stays available to users. We have [some tips and tricks on propagating this content](/docs/guides-faq#propagating-your-content-hash-through-ipfs) but ultimately someone will have to [pin](https://docs.ipfs.io/guides/concepts/pinning/) it.
+> Secondly, your app's frontend content is uploaded to IPFS and it becomes **your responsibility** to ensure that it stays available to users. Click [here](https://docs.ipfs.io/introduction/overview/) to learn more about IPFS and [pinning files]()(https://docs.ipfs.io/guides/concepts/pinning/).
 
 ## Setup
 
@@ -23,7 +23,9 @@ npx create-aragon-app app
 
 This will create a new directory named `app`, with everything you need.
 
-To interact with aragonPM we will use the [`aragon apm`](/docs/cli-apm-commands) commands.
+To interact with aragonPM we will use the [`Aragon Buidler plugin`](https://github.com/aragon/buidler-aragon) already installed in the boilerplate repository. 
+
+We will also need a running [IPFS server](https://docs.ipfs.io/guides/guides/install/). For this tutorial, we will assume that the IPFS server is running locally with its API port set to `5001`. 
 
 ## Introduction to environments
 
@@ -35,104 +37,79 @@ This app has 3 environments defined:
 | rinkeby     | rinkeby   |
 | mainnet     | mainnet   |
 
-Is a prerequisite to have a ENS Registry address defined.
+It is a prerequisite to have a ENS Registry address defined.
 
 Environments are defined in [`arapp.json`](/docs/cli-global-confg#the-arappjson-file), for example `rinkeby` points to:
 
 - An ENS registry: `0x98df287b6c145399aaa709692c8d308357bc085d`
-- An app name (repository and registry of aragonPM): `app.open.aragonpm.eth`
-- An Ethereum websockets provider: `wss://rinkeby.eth.aragon.network/ws` - to **read** from the blockchain
+- An app name (repository and registry of aragonPM): `app.aragonpm.eth`
 - An Ethereum network: `rinkeby`
 
-The `rinkeby` network is further defined in `truffle.js`, and has:
-
-- An Ethereum provider address: `https://rinkeby.infura.io` (to **write** to the blockchain)
-- An Ethereum account: `0xb41...6eE7` (which is the first account generated from the `DEFAULT_MNEMONIC` variable, to learn how to use a different account follow the [troubleshooting guide](/docs/guides-faq.html#set-a-private-key))
-
 > **Note**<br>
-> The `default` environment which points to `localhost` does not have an ENS Registry address specified because aragonCLI will default the value to `0xB9462EF3441346dBc6E49236Edbb0dF207db09B7` (the ENS Registry pre-deployed on the local development chain).
+> The `default` environment which points to `localhost` does not have an ENS Registry address specified because the Buidler plugin will default the value to `0xB9462EF3441346dBc6E49236Edbb0dF207db09B7` (the ENS Registry pre-deployed on the local development chain).
 
 ## Publish a major version: content + contract
 
-To publish on aragonPM we will use [`aragon apm publish`](/docs/cli-apm-commands#aragon-apm-publish) command.
-
-Command:
+To publish on aragonPM we will use the following buidler task:
 
 ```sh
-npx aragon apm publish major --environment rinkeby
+npx buidler publish major --network rinkeby
 ```
 
 This will:
 
-<span>![*](/docs/assets/check.svg) Apply version bump (major).</span>
-
-<span>![*](/docs/assets/check.svg) _Compile_ and _deploy_ the app's contract (by default the output lives in `build`)</span>
-
-<span>![*](/docs/assets/check.svg) _Build_ the app's [frontend (by default the output lives in `dist`)](#building-frontends)</span>
-
-<span>![*](/docs/assets/check.svg) Generate application artifact.</span>
-
-<span>![*](/docs/assets/check.svg) Publish the app to the **rinkeby** environment.</span>
+- Apply version bump (major).
+- _Compile_ and _deploy_ the app's contract (by default the output lives in `build`)
+- _Build_ the app's [frontend (by default the output lives in `dist`)](#building-frontends)
+- Generate application artifact.
+- Publish the app to the **rinkeby** environment.
+- Upload the app's frontend to the IPFS server.
 
 Sample output:
 
 ```sh
- > npx aragon apm publish major --environment rinkeby
-
- ✔ Successfully published app.open.aragonpm.eth v1.0.0:
- ℹ Contract address: 0xE636bcA5B95e94F749F63E322a04DB59362299F1
- ℹ Content (ipfs): QmR695Wu5KrHNec7pRP3kPvwYihABDAyVYdX5D5vwLgxCn
- ℹ Transaction hash: 0x3d752db29cc106e9ff98b260a90615921eb32471425a29ead8cbb830fb224d8
 ```
 
 > **Note**<br>
 > You can also deploy a major version with only frontend changes by passing `--only-content`.
 >
-> You can also just generate artifacts file without publishing by passing `--only-artifacts`.
->
 > The contract location is defined in `arapp.json` under `path`.
 
-## Publish a minor or patch version: content only
 
-Command:
+## Task syntax and options
 
-```sh
-npx aragon apm publish patch --environment rinkeby
-```
-
-This will:
-
-<span>![*](/docs/assets/check.svg) Apply version bump (patch).</span>
-
-<span>![*](/docs/assets/check.svg) _Build_ the app's [frontend (by default the output lives in `dist`)](#building-frontends)</span>
-
-<span>![*](/docs/assets/check.svg) Generate application artifact.</span>
-
-<span>![*](/docs/assets/check.svg) Publish the app to the **rinkeby** environment.</span>
-
-Sample output:
+The publish task has the following syntax:
 
 ```sh
- ✔ Successfully published app.open.aragonpm.eth v1.0.1:
- ℹ Contract address: 0xE636bcA5B95e94F749F63E322a04DB59362299F1
- ℹ Content (ipfs): QmUYv9cjyNVxCyAJGK2YXjkbzh6u4iW2ak81Z9obdefM1q
- ℹ Transaction hash: 0x57864d8efd8d439008621b494b19a3e8f876a8a46b38475f9626802f0a1403c2
+buidler publish [global options] <bump> [task options]
 ```
+
+Where `global options` are Buidler's [global options](https://buidler.dev/getting-started/#quick-start) and `bump` is the version bump (either `major`, `minor` or `patch`) or the semantic version. E.g. `minor` would increase version `1.2.0` to `1.3.0`.
+
+The following task options are available:
+
+- `contract`: Contract address previously deployed.
+- `manager-address`: Owner of the APM repo. Must be provided in the initial release.
+- `ipfs-api-url` (default: `http://localhost:5001`): IPFS API URL to connect to an ipfs daemon API server.
+- `only-content` (flag): Prevents contract compilation, deployment and artifact generation.
+- `verify` (flag): Enables Etherscan verification.
+- `dry-run` (flag): Output tx data without broadcasting.
+
 
 ## Check published versions
 
-To fetch the versions published on aragonPM we will use [`aragon apm versions`](https://hack.aragon.org/docs/cli-apm-commands#aragon-apm-versions) command.
+To fetch the versions published on aragonPM, we can use the [`aragon apm versions`](https://hack.aragon.org/docs/cli-apm-commands#aragon-apm-versions) command with aragonCLI.
 
 Command:
 
 ```sh
-npx aragon apm versions --environment rinkeby
+aragon apm versions --environment rinkeby
 ```
 
 Sample output:
 
 ```sh
- ℹ app.open.aragonpm.eth has 2 published versions
+ ℹ app.aragonpm.eth has 2 published versions
  ✔ 1.0.0: 0xE636bcA5B95e94F749F63E322a04DB59362299F1 ipfs:QmR695Wu5KrHNec7pRP3kPvwYihABDAyVYdX5D5vwLgxCn
  ✔ 1.0.1: 0xE636bcA5B95e94F749F63E322a04DB59362299F1 ipfs:QmUYv9cjyNVxCyAJGK2YXjkbzh6u4iW2ak81Z9obdefM1q
 ```
@@ -144,13 +121,13 @@ We will fetch the published versions of the official `voting` app on the rinkeby
 Command:
 
 ```sh
-npx aragon apm voting.aragonpm.eth --environment rinkeby
+aragon apm versions voting.aragonpm.eth --environment rinkeby
 ```
 
 Sample output:
 
 ```sh
-ℹ voting.aragonpm.eth has 13 published versions
+ℹ voting.aragonpm.eth has 24 published versions
  ✔ 1.0.0: 0x8C06aEBF29F20A2e09b32F5d44cEa49Db3EC2eE0 ipfs:QmQHhcbZRoTKkbjWdwXwqqWZzTNHUFzECPrfqie8f8oq45
  ✔ 1.1.0: 0x8C06aEBF29F20A2e09b32F5d44cEa49Db3EC2eE0 ipfs:QmT27VvGNiNeWj4tsZ5omDCc6KxaHU3N9uebFCsoxSAEpL
  ✔ 1.1.1: 0x8C06aEBF29F20A2e09b32F5d44cEa49Db3EC2eE0 ipfs:QmYmQVKj44FNjaY2qT4iWMWGSpKmnoseUw7idJkh9mtjei
@@ -166,25 +143,12 @@ Sample output:
  ✔ 2.0.3: 0xb4fa71b3352D48AA93D34d085f87bb4aF0cE6Ab5 ipfs:QmcgUz9PXaZwvA3m7fXPgjsEVKteuivLNSCDvxKGv8ztMa
 ```
 
-## More about environments
-
-The default environments used by aragonCLI are defined in [`environments.default.json`](https://github.com/aragon/aragon-cli/blob/master/packages/aragon-cli/config/environments.default.json). This file has 4 environments:
-
-| Environment    | Network   |
-| -------------- | --------- |
-| aragon:local   | localhost |
-| aragon:rinkeby | rinkeby   |
-| aragon:staging | rinkeby   |
-| aragon:mainnet | mainnet   |
-
-In case you have an `arapp.json` file in your app directory, aragonCLI will use your local configuration over the default.
-
 ## Building frontends
 
 Your application's frontend will have another build script associated with it, to transpile, bundle, and pack all of its assets (e.g. scripts, images, fonts, etc) together.
 
-If you've used one of the boilerplates, it's likely this has already been set up for you with [`parcel-bundler`](https://parceljs.org) and [aragonUI](/docs/aragonui-intro).
+If you've used the Aragon react boilerplate, this has already been set up for you with [`parcel-bundler`](https://parceljs.org) and [aragonUI](/docs/aragonui-intro).
 
 If you need to add, modify, or remove assets or the way the frontend is built, it's important to remember to **always** use **relative paths** to serve those assets. Usually, this can be accomplished by adding a `./` in front of the path.
 
-This is important because the Aragon client usually fetches all of an app's assets via an IPFS gateway, and non-relative paths break gateway resolutions. You can test this for yourself by attempting to access your app when it's published by going to an IPFS gateway (see [tips and tricks of propagating IPFS content](/docs/guides-faq#propagating-your-content-hash-through-ipfs)) and making sure its assets are being loaded correctly.
+This is important because in production, the Aragon client usually fetches all of an app's assets via an IPFS gateway, and non-relative paths break gateway resolutions. You can test this for yourself by attempting to access your app when it's published by going to an IPFS gateway and making sure its assets are being loaded correctly.

--- a/docs/guides-publish.md
+++ b/docs/guides-publish.md
@@ -27,6 +27,8 @@ To interact with aragonPM we will use the [`Aragon Buidler plugin`](https://gith
 
 We will also need a running [IPFS server](https://docs.ipfs.io/guides/guides/install/). For this tutorial, we will assume that the IPFS server is running locally with its API port set to `5001` and gateway to `8080`. 
 
+Excellent IPFS pinning services like [Pinata](https://pinata.cloud) and [Eternum](https://www.eternum.io) are also available for a reasonable price.
+
 ## Introduction to environments
 
 This app has 3 environments defined:
@@ -85,7 +87,7 @@ main     |
 main     |   Tx mined
 main     |   
 main     |   Status:        Success
-main     |   Block number:  78
+main     |   Block number:  6293860
 main     |   Gas used:      960591
 ```
 
@@ -107,17 +109,17 @@ Where `global options` are Buidler's [global options](https://buidler.dev/gettin
 
 The following task options are available:
 
-- `contract`: Contract address previously deployed.
-- `manager-address`: Owner of the APM repo. Must be provided in the initial release.
-- `ipfs-api-url` (default: `http://localhost:5001`): IPFS API URL to connect to an ipfs daemon API server.
+- `contract`: Address of the app's deployed smart contract.
+- `manager-address`: Permissions manager of the app's aragonPM repo. Must be provided in the initial release.
+- `ipfs-api-url` (default: `http://localhost:5001`): IPFS API URL to connect to an IPFS server.
 - `only-content` (flag): Prevents contract compilation, deployment and artifact generation.
 - `verify` (flag): Enables Etherscan verification.
-- `dry-run` (flag): Output tx data without broadcasting.
+- `dry-run` (flag): Output transaction data without broadcasting.
 
 
 ## Check published versions
 
-To fetch the versions published on aragonPM, we can use the [`aragon apm versions`](https://hack.aragon.org/docs/cli-apm-commands#aragon-apm-versions) command with aragonCLI.
+To fetch the versions published on aragonPM, we can use the [`aragon apm versions`](https://hack.aragon.org/docs/cli-apm-commands#aragon-apm-versions) command from aragonCLI.
 
 Command:
 
@@ -166,7 +168,7 @@ Sample output:
 
 Your application's frontend will have another build script associated with it, to transpile, bundle, and pack all of its assets (e.g. scripts, images, fonts, etc) together.
 
-If you've used the Aragon react boilerplate, this has already been set up for you with [`parcel-bundler`](https://parceljs.org) and [aragonUI](/docs/aragonui-intro).
+If you've used the Aragon React boilerplate, this has already been set up for you with [`parcel-bundler`](https://parceljs.org) and [aragonUI](/docs/aragonui-intro).
 
 If you need to add, modify, or remove assets or the way the frontend is built, it's important to remember to **always** use **relative paths** to serve those assets. Usually, this can be accomplished by adding a `./` in front of the path.
 

--- a/docs/guides-publish.md
+++ b/docs/guides-publish.md
@@ -11,11 +11,11 @@ This guide will show you how to publish an app to [aragonPM](/docs/package-manag
 > **Note**<br>
 > Publishing your app requires an on-chain action so you must connect an Ethereum account with enough funds on the selected environment to send a publish transaction.
 >
-> Secondly, your app's frontend content is uploaded to IPFS and it becomes **your responsibility** to ensure that it stays available to users. Click [here](https://docs.ipfs.io/introduction/overview/) to learn more about IPFS and [pinning files]()(https://docs.ipfs.io/guides/concepts/pinning/).
+> Secondly, your app's frontend content is uploaded to IPFS and it becomes **your responsibility** to ensure that it stays available to users. Click [here](https://docs.ipfs.io/introduction/overview/) to learn more about IPFS and [pinning files](https://docs.ipfs.io/guides/concepts/pinning/).
 
 ## Setup
 
-We'll start from the [React boilerplate](https://github.com/aragon/aragon-react-boilerplate).
+We'll start from the Aragon [React boilerplate](https://github.com/aragon/aragon-react-boilerplate).
 
 ```sh
 npx create-aragon-app app
@@ -25,7 +25,7 @@ This will create a new directory named `app`, with everything you need.
 
 To interact with aragonPM we will use the [`Aragon Buidler plugin`](https://github.com/aragon/buidler-aragon) already installed in the boilerplate repository. 
 
-We will also need a running [IPFS server](https://docs.ipfs.io/guides/guides/install/). For this tutorial, we will assume that the IPFS server is running locally with its API port set to `5001`. 
+We will also need a running [IPFS server](https://docs.ipfs.io/guides/guides/install/). For this tutorial, we will assume that the IPFS server is running locally with its API port set to `5001` and gateway to `8080`. 
 
 ## Introduction to environments
 
@@ -68,8 +68,6 @@ This will:
 Sample output:
 
 ```sh
-main     |   Deploy new repo to registry aragonpm.eth
-main     | 
 main     |   App name:          app.aragonpm.eth
 main     |   Initial version:   1.0.0
 main     |   Manager address:   0x5Ddb5ec4fF143fDaBCCD0a47F30FF2ce319C2a01
@@ -102,7 +100,7 @@ main     |   Gas used:      960591
 The publish task has the following syntax:
 
 ```sh
-buidler publish [global options] <bump> [task options]
+npx buidler publish [global options] <bump> [task options]
 ```
 
 Where `global options` are Buidler's [global options](https://buidler.dev/getting-started/#quick-start) and `bump` is the version bump (either `major`, `minor` or `patch`) or the semantic version. E.g. `minor` would increase version `1.2.0` to `1.3.0`.

--- a/docs/guides-publish.md
+++ b/docs/guides-publish.md
@@ -68,6 +68,27 @@ This will:
 Sample output:
 
 ```sh
+main     |   Deploy new repo to registry aragonpm.eth
+main     | 
+main     |   App name:          app.aragonpm.eth
+main     |   Initial version:   1.0.0
+main     |   Manager address:   0x5Ddb5ec4fF143fDaBCCD0a47F30FF2ce319C2a01
+main     |   Contract address:  0x2e25c8F88c5cCcbC9400e5bc86cF9C58C7604327
+main     |   ContentURI:        QmTBapuxxzFHzxdbxxZUmdEmyRxQohxoK7qiXiJ6id36tu
+main     | 
+main     |   http://localhost:8080/ipfs/QmTBapuxxzFHzxdbxxZUmdEmyRxQohxoK7qiXiJ6id36tu
+main     | 
+main     | 
+main     |   Tx sent
+main     | 
+main     |   Tx hash:  0x954fa737215152d2c9be5893bcda91cf889b30dd5e26bada10b657e87b89692f
+main     |   
+main     | 
+main     |   Tx mined
+main     |   
+main     |   Status:        Success
+main     |   Block number:  78
+main     |   Gas used:      960591
 ```
 
 > **Note**<br>


### PR DESCRIPTION
- Convert existing publish guide to the Buidler plugin's

## TODO

- ~Add section about Etherscan verification~

The Etherscan verification section will be added later since the option is currently not working.