### PR TITLE
CI: update solc installation to target 0.4.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,11 @@ jobs:
           curl -s -f -L "https://github.com/ethereum/solidity/releases/download/v0.4.24/solc-static-linux" -o "$HOME/bin/solc"
           chmod u+x "$HOME/bin/solc"
           echo "Installed solc-v0.4.24"
-          export PATH=$HOME/bin/solc:$PATH
+          export PATH=$HOME/bin:$PATH
           solc --version
       - name: build
         run: |
-          export PATH=$HOME/bin/solc:$PATH
+          export PATH=$HOME/bin:$PATH
           solc --version
           yarn run build
         working-directory: ./website

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: deploy
 
 on:
   push:
-    branches:
-      - master
 
 jobs:
   deploy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,16 @@ jobs:
         working-directory: ./website
       - name: install solc
         run: |
-          git clone https://github.com/crytic/solc-select.git
-          ./solc-select/scripts/install.sh
-          export PATH=/$HOME/.solc-select:$PATH
-          solc use 0.4.24
+          # Install solc v0.4.24 manually onto Linux
+          mkdir -p "$HOME/bin"
+          curl -s -f -L "https://github.com/ethereum/solidity/releases/download/v0.4.24/solc-static-linux" -o "$HOME/bin/solc"
+          chmod u+x "$HOME/bin/solc"
+          echo "Installed solc-v0.4.24"
+          export PATH=$HOME/bin/solc:$PATH
+          solc --version
       - name: build
         run: |
-          export PATH=/$HOME/.solc-select:$PATH
+          export PATH=$HOME/bin/solc:$PATH
           solc --version
           yarn run build
         working-directory: ./website


### PR DESCRIPTION
Switches from using `solc-select` to downloading the specific solc v0.4.24 binary via `curl`.

This fixes CI because of 0.4.24 is now not in the first page of releases via the Github API, and should also make CI faster because it targets installation of a single solc version.